### PR TITLE
Fixup nimble install

### DIFF
--- a/src/threecode/fatprompt/runtime.nim
+++ b/src/threecode/fatprompt/runtime.nim
@@ -4,7 +4,8 @@
 ## turn is running. The turn controller calls these helpers directly and also
 ## registers them as API stream hooks. `api.nim` must not import this module.
 
-import std/[atomics, json, locks, os, strformat, strutils, terminal, times, unicode]
+import std/[atomics, json, locks, os, strformat, strutils, terminal, times]
+import std/unicode except strip
 when defined(posix):
   import std/posix except SocketHandle
   import posix/termios

--- a/src/threecode/util.nim
+++ b/src/threecode/util.nim
@@ -1,4 +1,5 @@
-import std/[net, os, sequtils, strformat, strutils, unicode, times]
+import std/[net, os, sequtils, strformat, strutils, times]
+import std/unicode except strip
 import types
 import threecode/unicodewidth
 

--- a/src/threecode/web.nim
+++ b/src/threecode/web.nim
@@ -5,7 +5,8 @@
 ## No external binaries, no scripting runtimes, pure Nim httpclient + a
 ## hand-rolled HTML-to-text pass.
 
-import std/[httpclient, strutils, uri, unicode, tables]
+import std/[httpclient, strutils, uri, tables]
+import std/unicode except strip
 import util
 
 const UserAgent = "Mozilla/5.0 (X11; Linux x86_64) 3code/web"

--- a/threecode.nimble
+++ b/threecode.nimble
@@ -6,8 +6,8 @@ srcDir        = "src"
 namedBin["threecode"] = "3code"
 
 requires "nim >= 2.0.0"
-requires "streamhttp >= 0.2.0"
-requires "ttty >= 0.2.0"
+requires "https://github.com/capocasa/streamhttp >= 0.2.0"
+requires "https://github.com/capocasa/ttty >= 0.2.0"
 requires "unicodedb >= 0.13.0"
 requires "https://github.com/capocasa/tinotify >= 0.1.0"
 


### PR DESCRIPTION
Hey there! I've been meaning to try out 3code since you announced it.
This just fixes a couple stumbles on the nimble install workflow.
Awesome project!

- a couple of the capocasa dependencies required full repo path resolution since they're not on nimble package list yet
- a few source files had a `strip()` conflict between strutils and unicode