### PR TITLE
fixes strutils & unicode ambiguity for strip()

### DIFF
--- a/src/threecode/fatprompt/runtime.nim
+++ b/src/threecode/fatprompt/runtime.nim
@@ -4,7 +4,8 @@
 ## turn is running. The turn controller calls these helpers directly and also
 ## registers them as API stream hooks. `api.nim` must not import this module.
 
-import std/[atomics, json, locks, os, strformat, strutils, terminal, times, unicode]
+import std/[atomics, json, locks, os, strformat, strutils, terminal, times]
+import std/unicode except strip
 when defined(posix):
   import std/posix except SocketHandle
   import posix/termios

--- a/src/threecode/util.nim
+++ b/src/threecode/util.nim
@@ -1,4 +1,5 @@
-import std/[net, os, sequtils, strformat, strutils, tables, unicode, times]
+import std/[net, os, sequtils, strformat, strutils, tables, times]
+import std/unicode except strip
 import types
 import threecode/unicodewidth
 

--- a/src/threecode/web.nim
+++ b/src/threecode/web.nim
@@ -5,7 +5,8 @@
 ## No external binaries, no scripting runtimes, pure Nim httpclient + a
 ## hand-rolled HTML-to-text pass.
 
-import std/[httpclient, strutils, uri, unicode, tables]
+import std/[httpclient, strutils, uri, tables]
+import std/unicode except strip
 import util
 
 const UserAgent = "Mozilla/5.0 (X11; Linux x86_64) 3code/web"


### PR DESCRIPTION
Hey, the nimble repo publishing of the dependencies worked well!
I still see an issue with symbol ambiguity when trying to build 3code.
This PR shows how it resolves it for me - it's a simple fix.