### PR TITLE
Feat alt fb word motion

### DIFF
--- a/src/threecode/fatprompt/runtime.nim
+++ b/src/threecode/fatprompt/runtime.nim
@@ -1788,11 +1788,12 @@ proc inputThreadProc() {.thread.} =
             continue
         -1
       let hasPendingInput: minline.HasPendingInputProc = proc(): bool =
-        # Peek-aware: only report a pending tail when the next buffered byte
-        # is a valid escape-sequence continuation. A printable byte (the
-        # user's next keystroke right after pressing Escape) stays in the
-        # buffer for normal processing, so ESC + typing cancels instead of
-        # swallowing the first typed character.
+        # Peek-aware: report a pending tail when the next buffered byte is
+        # a valid escape-sequence continuation. Printable letters count as
+        # tails (Alt-chord halves, e.g. ESC f = Alt+F); a bare Escape has
+        # no tail within the EscapeTailPollMs window, so it cancels.
+        # `handleEscape` dispatches bound Alt chords and cancels+putbacks
+        # unbound ones, so ESC-then-typing still interrupts cleanly.
         if pendingInput.len == 0:
           discard fillPending(minline.EscapeTailPollMs.cint)
         pendingInput.len > 0 and minline.isEscapeTailByte(pendingInput[0])

--- a/src/threecode/minline.nim
+++ b/src/threecode/minline.nim
@@ -207,6 +207,7 @@ type
     canceled*: bool
     eof*: bool
     hidechars*: bool
+    escPutback*: int           ## byte stashed by `handleEscape` when an Alt chord's letter has no KEYMAP binding; drained by the readLine loop so it prints as normal input after the cancel.
     wizardMode*: bool         ## true while a modal provider wizard owns the editor; alters ctrl+c/ctrl+d/esc
     complPrefix*: string       ## original prefix before first completion
     complMatches*: seq[string] ## current match list
@@ -272,15 +273,19 @@ template callHook*(hook, ed: untyped) =
 
 proc isEscapeTailByte*(b: int): bool =
   ## True when `b` can validly be the second byte of a terminal escape
-  ## sequence (the byte immediately following a leading ESC). Printable
-  ## letters are never valid continuations, so an ESC immediately
-  ## followed by the user's next typed character is correctly classified
-  ## as a bare Escape rather than swallowing that character as a tail.
+  ## sequence (the byte immediately following a leading ESC). This
+  ## includes Alt+<key> chords, which terminals send as ``ESC <byte>``
+  ## bursts: a printable letter is a valid tail because it is the letter
+  ## half of an Alt chord (e.g. Alt+F = ``ESC f``). A bare Escape (user
+  ## pressed Escape, then started typing) has no tail byte within the
+  ## ``EscapeTailPollMs`` poll window, so it cancels before we ever peek.
   ##
   ## CSI (ESC [), SS3 (ESC O), Alt+Enter (ESC CR), and the digit/~
-  ## continuations used by xterm/kitty function keys are the real tails.
-  b == 91 or b == 79 or b == 13 or (b >= 48 and b <= 57) or b == 126 or
-    b == 92 or b == 93 or b == 94 or b == 95
+  ## continuations used by xterm/kitty function keys are the other tails.
+  ## ``handleEscape`` decides what to do with an Alt chord whose letter
+  ## has no KEYMAP binding: it cancels like a bare Escape and puts the
+  ## letter back so it is not swallowed.
+  b == 13 or b == 8 or (b >= 32 and b <= 126)
 
 # ---------- Pure helpers (testable without IO) ----------
 
@@ -1231,10 +1236,10 @@ proc stdinHasByteNow*(): bool =
 proc terminalHasPendingInput*(): bool =
   ## Return whether stdin has a pending byte that could be the tail of an
   ## ESC-prefixed escape sequence. Polls briefly for burst-delivered
-  ## sequences, then peeks at the actual byte: a printable character is
-  ## never a valid escape continuation, so it is stashed for `getchr` to
-  ## return normally and this reports no tail (bare Escape). Only genuine
-  ## continuation bytes (CSI `[`, SS3 `O`, etc.) report a tail.
+  ## sequences (Alt chords, CSI/SS3 function keys), then peeks at the
+  ## byte. A bare Escape (no byte within the poll window) reports no
+  ## tail so `handleEscape` cancels; any byte that arrives — including
+  ## printable Alt-chord letters — is stashed and reported as a tail.
   when defined(posix):
     if isatty(0.cint) != 0:
       var pfd: TPollfd
@@ -1244,11 +1249,8 @@ proc terminalHasPendingInput*(): bool =
       if r > 0 and (pfd.revents and POLLIN) != 0:
         var ch: char
         if posix.read(0.cint, addr ch, 1) == 1:
-          if isEscapeTailByte(ch.ord.int):
-            termPeeked = ch.ord.int
-            return true
           termPeeked = ch.ord.int
-          return false
+          return isEscapeTailByte(ch.ord.int)
       return false
   true
 
@@ -1268,6 +1270,7 @@ proc initEditor*(mode = mdInsert, historySize = 256, historyFile: string = ""): 
   result.history = historyInit(historySize, historyFile)
   result.width = 80
   result.contPrompt = "  "
+  result.escPutback = -1
 
 proc resetForRead(ed: var LineEditor, prompt: string, hidechars: bool) =
   if ed.prefillText.len > 0:
@@ -1340,11 +1343,25 @@ proc handleEscape*(ed: var LineEditor, c1: int): bool =
   # A real Alt chord arrives as a burst so `hasPendingEscapeTail` saw
   # the letter as a tail and routed us here; a bare Escape (human-paced)
   # already canceled at the top of this proc.
+  const StructuralTail = {91, 79, 48..57, 126, 92, 93, 94, 95}
+    ## Second bytes that introduce a longer structural escape sequence
+    ## (CSI ``[``, SS3 ``O``, xterm/kitty digit-``~`` tails, etc.). These
+    ## have explicit handlers below and must NOT be treated as Alt-chord
+    ## letters even though they fall in the printable range.
   var altName: string
   if c2 == 8: altName = "alt+h"        # Ctrl+Alt+H = ESC + backspace byte
-  elif c2 in 32..126: altName = "alt+" & c2.char.toLowerAscii
+  elif c2 in 32..126 and c2 notin StructuralTail:
+    altName = "alt+" & c2.char.toLowerAscii
   if altName.len > 0 and KEYMAP.hasKey(altName):
     KEYMAP[altName](ed)
+    return false
+  # ESC + printable letter with no KEYMAP binding: treat the ESC as a bare
+  # cancel and put the letter back so the readLine loop prints it instead
+  # of swallowing it. Structural tails (CSI, SS3, digit/~) fall through to
+  # their own handlers below.
+  if altName.len > 0:
+    ed.escPutback = c2
+    KEYMAP["ctrl+c"](ed)
     return false
   if c2 == 91:  # CSI
     let c3 = escCh(25)
@@ -1496,7 +1513,10 @@ proc readLineWith*(ed: var LineEditor, prompt: string,
       ed.write "\x1b[?25h"
   while true:
     var suffixJustCleared = false
-    if putback >= 0:
+    if ed.escPutback >= 0:
+      c1 = ed.escPutback
+      ed.escPutback = -1
+    elif putback >= 0:
       c1 = putback
       putback = -1
     else:

--- a/src/threecode/minline.nim
+++ b/src/threecode/minline.nim
@@ -774,6 +774,29 @@ proc deleteWordLeft*(ed: var LineEditor) =
   callHook(ed.onMutate, ed)
   fullRedraw(ed)
 
+proc deleteToBoundaryLeft*(ed: var LineEditor) =
+  ## Delete back to the most recent non-alphanumeric boundary. Like
+  ## readline's ``backward-kill-word``: first skip any non-word chars
+  ## (``/``, ``.``, etc.) immediately to the left, then delete the
+  ## alphanumeric run. This peels one path segment per press
+  ## (``/usr/local/bin`` -> ``/usr/local/`` -> ``/usr/``) instead of
+  ## stalling when the cursor lands right after a delimiter.
+  var p = ed.line.position
+  let stop = ed.line.position
+  while p > 0:
+    let c = ed.line.text[p - 1]
+    if c.isAlphanumeric or c == '_': break
+    dec p
+  while p > 0:
+    let c = ed.line.text[p - 1]
+    if not (c.isAlphanumeric or c == '_'): break
+    dec p
+  if p == stop: return
+  ed.line.text = ed.line.text[0 ..< p] & ed.line.text[stop .. ^1]
+  ed.line.position = p
+  callHook(ed.onMutate, ed)
+  fullRedraw(ed)
+
 proc visualUp*(ed: var LineEditor) =
   ## Move up by one visual row, preserving the visual column as best as
   ## possible. If already on the top visual row of the buffer, fall back
@@ -972,6 +995,9 @@ KEYMAP["ctrl+e"]    = proc(ed: var LineEditor) = ed.goToEnd()
 KEYMAP["home"]      = proc(ed: var LineEditor) = ed.goToStart()
 KEYMAP["end"]       = proc(ed: var LineEditor) = ed.goToEnd()
 KEYMAP["ctrl+w"]    = proc(ed: var LineEditor) = ed.deleteWordLeft()
+KEYMAP["alt+b"]     = proc(ed: var LineEditor) = ed.wordLeft()
+KEYMAP["alt+f"]     = proc(ed: var LineEditor) = ed.wordRight()
+KEYMAP["alt+h"]     = proc(ed: var LineEditor) = ed.deleteToBoundaryLeft()
 KEYMAP["ctrl+c"]    = proc(ed: var LineEditor) =
   ed.canceled = true
   raise newException(InputCancelled, "")
@@ -1078,6 +1104,9 @@ proc initKeyTables*() =
   KEYMAP["home"]      = proc(ed: var LineEditor) = ed.goToStart()
   KEYMAP["end"]       = proc(ed: var LineEditor) = ed.goToEnd()
   KEYMAP["ctrl+w"]    = proc(ed: var LineEditor) = ed.deleteWordLeft()
+  KEYMAP["alt+b"]     = proc(ed: var LineEditor) = ed.wordLeft()
+  KEYMAP["alt+f"]     = proc(ed: var LineEditor) = ed.wordRight()
+  KEYMAP["alt+h"]     = proc(ed: var LineEditor) = ed.deleteToBoundaryLeft()
   KEYMAP["ctrl+c"]    = proc(ed: var LineEditor) =
     if ed.wizardMode:
       # In the provider wizard, Ctrl-C clears the line if text is
@@ -1306,6 +1335,16 @@ proc handleEscape*(ed: var LineEditor, c1: int): bool =
   if c1 != 27: return false
   if c2 == 13:
     ed.insertNewline()
+    return false
+  # Alt+<key> two-byte sequences: ESC followed by the key's byte.
+  # A real Alt chord arrives as a burst so `hasPendingEscapeTail` saw
+  # the letter as a tail and routed us here; a bare Escape (human-paced)
+  # already canceled at the top of this proc.
+  var altName: string
+  if c2 == 8: altName = "alt+h"        # Ctrl+Alt+H = ESC + backspace byte
+  elif c2 in 32..126: altName = "alt+" & c2.char.toLowerAscii
+  if altName.len > 0 and KEYMAP.hasKey(altName):
+    KEYMAP[altName](ed)
     return false
   if c2 == 91:  # CSI
     let c3 = escCh(25)

--- a/tests/core/test_minline.nim
+++ b/tests/core/test_minline.nim
@@ -334,6 +334,84 @@ suite "minline editor: cursor navigation":
     d.push Enter
     check d.run(ed, prompt = "> ") == "<foo bar\nbaz qux"
 
+  test "Alt+F moves forward to start of next word":
+    var ed = initEditor()
+    let d = newDriver()
+    d.pushString "foo bar baz"
+    d.push CtrlA          # start of line
+    d.push AltF           # forward -> start of 'bar' (pos 4)
+    d.pushString "<"
+    d.push Enter
+    check d.run(ed, prompt = "> ") == "foo <bar baz"
+
+  test "Alt+F at last word lands at end of buffer":
+    var ed = initEditor()
+    let d = newDriver()
+    d.pushString "foo bar"
+    d.push CtrlA          # start
+    d.push AltF           # -> start of 'bar' (pos 4)
+    d.push AltF           # -> end (pos 7)
+    d.pushString "<"
+    d.push Enter
+    check d.run(ed, prompt = "> ") == "foo bar<"
+
+  test "Alt+B moves backward to start of previous word":
+    var ed = initEditor()
+    let d = newDriver()
+    d.pushString "foo bar baz"
+    # cursor at end (pos 11); Alt+B x2 lands at start of 'bar' (pos 4)
+    d.push AltB           # back -> start of 'baz' (pos 8)
+    d.push AltB           # back -> start of 'bar' (pos 4)
+    d.pushString "<"
+    d.push Enter
+    check d.run(ed, prompt = "> ") == "foo <bar baz"
+
+  test "Alt+B at first word lands at start of buffer":
+    var ed = initEditor()
+    let d = newDriver()
+    d.pushString "foo bar"
+    d.push AltB           # back -> start of 'bar' (pos 4)
+    d.push AltB           # back -> start of 'foo' (pos 0)
+    d.pushString "<"
+    d.push Enter
+    check d.run(ed, prompt = "> ") == "<foo bar"
+
+  test "Alt+F then Alt+B round-trips to buffer start":
+    var ed = initEditor()
+    let d = newDriver()
+    d.pushString "alpha beta"
+    d.push CtrlA          # pos 0
+    d.push AltF           # -> start of 'beta' (pos 6)
+    d.push AltB           # -> start of 'alpha' (pos 0)
+    d.pushString "<"
+    d.push Enter
+    check d.run(ed, prompt = "> ") == "<alpha beta"
+
+  test "Ctrl+Alt+H deletes back to the most recent word boundary":
+    var ed = initEditor()
+    let d = newDriver()
+    d.pushString "/usr/local/bin"
+    d.push CtrlAltH       # delete 'bin' back to '/'
+    d.push Enter
+    check d.run(ed, prompt = "> ") == "/usr/local/"
+
+  test "Ctrl+Alt+H peels one segment at a time":
+    var ed = initEditor()
+    let d = newDriver()
+    d.pushString "a/b/c"
+    d.push CtrlAltH       # delete 'c'
+    d.push CtrlAltH       # delete 'b'
+    d.push Enter
+    check d.run(ed, prompt = "> ") == "a/"
+
+  test "Ctrl+Alt+H stops at non-alphanumeric, keeps the boundary char":
+    var ed = initEditor()
+    let d = newDriver()
+    d.pushString "name.value"
+    d.push CtrlAltH       # delete 'value' back to '.'
+    d.push Enter
+    check d.run(ed, prompt = "> ") == "name."
+
 # ---------------- Driver: multiline newlines ----------------
 
 suite "minline editor: newline insertion (multiline)":

--- a/tests/core/test_minline.nim
+++ b/tests/core/test_minline.nim
@@ -228,14 +228,19 @@ suite "minline editor: cursor navigation":
     check minline.isEscapeTailByte(48)   # '0'
     check minline.isEscapeTailByte(57)   # '9'
     check minline.isEscapeTailByte(126)  # '~'
-    # Printable letters are NEVER valid tails. This is the key property:
-    # ESC immediately followed by the user's next typed character must be
-    # treated as a bare Escape so the character is not swallowed.
-    check not minline.isEscapeTailByte('a'.ord)
-    check not minline.isEscapeTailByte('z'.ord)
-    check not minline.isEscapeTailByte('A'.ord)
-    check not minline.isEscapeTailByte('w'.ord)
-    check not minline.isEscapeTailByte(' '.ord)
+    # Printable letters ARE valid tails: a real Alt chord (Alt+F, Alt+B,
+    # ...) arrives as an ESC + letter burst, so the letter half must be
+    # recognized as a continuation. `handleEscape` decides per-binding
+    # whether to dispatch the chord or fall back to a bare-Esc cancel.
+    check minline.isEscapeTailByte('f'.ord)
+    check minline.isEscapeTailByte('b'.ord)
+    check minline.isEscapeTailByte('a'.ord)
+    check minline.isEscapeTailByte('z'.ord)
+    check minline.isEscapeTailByte('A'.ord)
+    check minline.isEscapeTailByte('w'.ord)
+    check minline.isEscapeTailByte(' '.ord)
+    # Ctrl+Alt+H arrives as ESC + backspace byte (0x08).
+    check minline.isEscapeTailByte(8)
 
   test "bare Escape cancels like Ctrl+C":
     var ed = initEditor()
@@ -918,12 +923,14 @@ suite "minline editor: termPeeked drain":
     check got == "X"
     check termPeeked == -1
 
-  test "peeked non-tail byte survives Esc cancel":
+  test "unbound Alt chord cancels and puts the letter back":
+    # ESC + a printable letter with no KEYMAP binding behaves like a
+    # bare Escape (cancel) but the letter is stashed in `escPutback` so
+    # the next readLineWith prints it instead of swallowing it. This is
+    # the burst-chord equivalent of bare-Esc-then-typing.
     termPeeked = -1
     var ed = initEditor()
     let d = newDriver()
-    # pendingInput peeks at next byte and, if not an escape tail,
-    # stashes it in termPeeked (mirroring terminalHasPendingInput).
     d.pendingInput = proc(): bool =
       if d.terminal.input.hasPendingInput:
         let b = d.terminal.input.read()
@@ -937,13 +944,13 @@ suite "minline editor: termPeeked drain":
     d.pushString "x"
     expect InputCancelled:
       discard d.run(ed, prompt = "> ")
-    # After cancel, termPeeked holds 'x'. A fresh readLineWith must
-    # drain it so the character is not lost.
-    check termPeeked == 'x'.ord
+    # 'x' is a printable tail, so it was consumed as the chord letter and
+    # stashed in escPutback (not termPeeked) for the next readLineWith.
+    check ed.escPutback == 'x'.ord
     d.push Enter
     let got = d.run(ed, prompt = "> ")
     check got == "x"
-    check termPeeked == -1
+    check ed.escPutback == -1
 
   test "peeked tail byte feeds escape sequence":
     termPeeked = -1

--- a/tests/minline_testutils.nim
+++ b/tests/minline_testutils.nim
@@ -48,6 +48,9 @@ const
   CtrlE* = @[5]
   CtrlLeft* = @[27, 91, 49, 59, 53, 68]
   CtrlRight* = @[27, 91, 49, 59, 53, 67]
+  AltB* = @[27, 98]   # Alt+B: back one word
+  AltF* = @[27, 102]  # Alt+F: forward one word
+  CtrlAltH* = @[27, 8]  # Ctrl+Alt+H: delete back to word boundary
   AltEnter* = KeyAltEnter
   KittyShiftEnter = KeyKittyShiftEnter
   XModShiftEnter = KeyModifyOtherShiftEnter

--- a/tests/tty/test_interrupt_prestream_freeze.nim
+++ b/tests/tty/test_interrupt_prestream_freeze.nim
@@ -190,6 +190,12 @@ suite "interrupt during pre-stream freeze regression":
     tty.drain(200)
     # ESC then immediately type the follow-up, before the turn ends.
     tty.send "\x1b"
+    # Wait for the interrupt to land before typing the follow-up. ESC is
+    # the prefix of Alt chords (Alt+F, Alt+B, ...) which arrive as a burst
+    # within the escape-tail poll; a human pressing ESC to interrupt then
+    # typing has a gap well past it. Synchronizing on the interrupt notice
+    # (rather than a fixed delay) keeps the race realistic and CI-stable.
+    tty.expectInHistory "interrupted by user"
     tty.send "hello model"
     tty.send "\n"
     # Whatever path it took (queued-then-sent, or sent after interrupt), the

--- a/tests/tty/test_tty_functional.nim
+++ b/tests/tty/test_tty_functional.nim
@@ -168,6 +168,15 @@ proc startStub(root: string; args: openArray[string] = ["-x", "-i"];
   newTtySession(ensureStubBinary(), args = args, cwd = root / "run",
                 env = stubEnv(root, resp), cols = cols, rows = rows)
 
+proc sendAltChord(s: TtySession; letter: char) =
+  ## Write ESC + letter as a single 2-byte burst to the PTY master,
+  ## bypassing `send`'s printable-echo waiting: an Alt chord doesn't
+  ## echo the letter (it triggers a motion/delete action instead), so
+  ## `send` would stall waiting for the letter to appear on screen.
+  var buf: array[2, char] = ['\x1b', letter]
+  discard posix.write(s.masterFd, addr buf[0], 2)
+  s.drain(30)
+
 proc requireVisibleEditorCaret(s: TtySession; needle: string) =
   s.drain(20)
   require s.frames.len > 0
@@ -1040,6 +1049,46 @@ suite "terminal visual contract":
     tty.expectTypedAtPrompt "after cancel"
     tty.send "\n"
     tty.expectInHistory "after cancel"
+
+  test "alt+f and alt+b move by word at idle":
+    # Alt+F / Alt+B arrive as ESC + letter bursts. They must be recognized
+    # as word-motion chords, not treated as a bare ESC (cancel) followed by
+    # a stray letter. Regression: isEscapeTailByte rejected printable tails,
+    # so the ESC half canceled the draft and the letter printed into the
+    # cleared line (visible as the whole draft vanishing + a lone f/b).
+    let root = newFixture("alt_word_motion")
+    writeConfiguredProvider(root)
+    writeStubResponses(root, %*[
+      {"role": "assistant", "content": "ok",
+       "contentChunks": ["ok"],
+       "usage": {"promptTokens": 5, "completionTokens": 1,
+                  "totalTokens": 6, "cachedTokens": 0}}
+    ])
+    let tty = startStub(root)
+    defer:
+      tty.writeFrameArtifact(root / "frames.txt")
+      tty.close()
+    tty.expect "❯"
+    tty.send "foo bar baz"
+    tty.expectTypedAtPrompt "foo bar baz"
+    # Ctrl+A to start (pos 0), then Alt+F forward to start of "bar" (pos 4).
+    tty.send "\x01"
+    tty.drain 20
+    tty.sendAltChord('f')
+    # Insert a digit marker at the cursor (between "foo " and "bar").
+    tty.send "1"
+    tty.expectTypedAtPrompt "foo 1bar baz"
+    # Alt+F again -> forward to start of "baz" (now pos 9 after the insert).
+    tty.sendAltChord('f')
+    tty.send "2"
+    tty.expectTypedAtPrompt "foo 1bar 2baz"
+    # Alt+B back to start of "2baz" (pos 9), then again to "1bar" (pos 5).
+    tty.sendAltChord('b')
+    tty.sendAltChord('b')
+    tty.send "0"
+    tty.expectTypedAtPrompt "foo 01bar 2baz"
+    tty.send "\n"
+    tty.expectInHistory "foo 01bar 2baz"
 
   test "ctrl-c during bash tool then prompt accepts input":
     let root = newFixture("ctrlc_during_bash")


### PR DESCRIPTION
Adds more word nav similar to readline: `alt+f` (forward) `alt+b` (backward) and `ctrl+alt+h` (delete back to word boundary)